### PR TITLE
Fix NoMethodError for ActiveRecord 7.1.2 in ShortenerGenerator

### DIFF
--- a/lib/generators/shortener/shortener_generator.rb
+++ b/lib/generators/shortener/shortener_generator.rb
@@ -9,7 +9,7 @@ class ShortenerGenerator < Rails::Generators::Base
   end
 
   def self.next_migration_number(dirname)
-    if ActiveRecord::Base.timestamped_migrations
+    if ActiveRecord.timestamped_migrations
       Time.new.utc.strftime("%Y%m%d%H%M%S")
     else
       "%.3d" % (current_migration_number(dirname) + 1)


### PR DESCRIPTION
Running `rails generate shortener` on ActiveRecord 7.1.2 produces a `NoMethodError`:

```
~/.rvm/gems/ruby-3.2.2@maitre-d/gems/activerecord-7.1.2/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `timestamped_migrations' for ActiveRecord::Base:Class (NoMethodError)
	from ~/.rvm/gems/ruby-3.2.2@maitre-d/gems/shortener-1.0.1/lib/generators/shortener/shortener_generator.rb:12:in `next_migration_number'
	from ~/.rvm/gems/ruby-3.2.2@maitre-d/gems/railties-7.1.2/lib/rails/generators/migration.rb:43:in `set_migration_assigns!'
	from ~/.rvm/gems/ruby-3.2.2@maitre-d/gems/railties-7.1.2/lib/rails/generators/migration.rb:59:in `migration_template'
	from ~/.rvm/gems/ruby-3.2.2@maitre-d/gems/shortener-1.0.1/lib/generators/shortener/shortener_generator.rb:20:in `create_migration_file'
```

This was resolved by replacing `ActiveRecord::Base.timestamped_migrations` with `ActiveRecord.timestamped_migrations`